### PR TITLE
add option to retry on error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Default: Returns `true` if [http.incomingMessage](https://nodejs.org/api/http.ht
 
 ```js
 var opts = {
-  shouldRetryFn: function (incomingHttpMessage) {
+  shouldRetryFn: function (error, incomingHttpMessage) {
     return incomingHttpMessage.statusMessage !== 'OK';
   }
 };
@@ -97,6 +97,29 @@ var opts = {
 
 request(urlThatReturns503, opts, function (err, resp, body) {
   // Your provided `originalRequest` instance was used.
+});
+```
+
+#### `opts.retryOnError`
+
+Type: `Boolean`
+
+Default: `false`
+
+```js
+var opts = {
+  retryOnError: true,
+  request: function(reqOpts, callback) {
+    return someOtherTransportThatMightThrowAnError(reqOpts, callback);
+  },
+  shouldRetryFn: function(error, incomingHttpMessage) {
+    return error.message = 'Oh noes!';
+  }
+};
+
+request(optionsForDifferentTransport, opts, function (err, resp, body) {
+  // A custom transport was used and the requests
+  // were retried twice even though an error was thrown
 });
 ```
 

--- a/test.js
+++ b/test.js
@@ -177,6 +177,26 @@ describe('retry-request', function () {
 
       retryRequest(URI_200, opts, function () {});
     });
+
+    it('should allow overriding retryOnError', function(done) {
+      var error = new Error('Oh noes!');
+      var requestCount = 0;
+      var opts = {
+        retryOnError: true,
+        request: function(reqOpts, callback) {
+          requestCount++;
+          callback(error);
+        },
+        shouldRetryFn: function (_error) {
+          return error === _error;
+        }
+      };
+
+      retryRequest(URI_200, opts, function () {
+        assert.strictEqual(requestCount, 3);
+        done();
+      });
+    });
   });
 
   it('should not do any retries if unnecessary', function (done) {


### PR DESCRIPTION
### Breaking change ahead!

Previously

```js
var opts = {
  shouldRetryFn: function(response) {
    return response.statusCode === whateva;
  }
};
```

Now

```js
var opts = {
  shouldRetryFn: function(error, response) {
    return response.statusCode === whateva;
  }
};
```

### `retryOnError` option

This adds support for a new option, `retryOnError`, that allows you retry requests in the event of an error, whereas previously we would exit early. This can be useful when using transports other than `request`

```js
var opts = {
  retryOnError: true,
  request: function(reqOpts, callback) {
    someOtherTransport(reqOpts, callback);
  },
  shouldRetryFn: function(err) {
    // retry based off of custom errors thrown by transport
    return err && err.code === 14;
  }
};
```