### PR TITLE
remove stream-cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "dependencies": {
     "request": "^2.69.0",
-    "stream-cache": "0.0.2",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I don't think using stream-cache is actually necessary. Just using a through stream seems to hold the data just fine until a stream is connected to it.