### PR TITLE
assign once listeners & removeAllListeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,8 @@ function retryRequest(requestOpts, opts, callback) {
   var requestStream;
   var delayStream;
 
+  var removeAllListeners;
+
   var activeRequest;
   var retryRequest = {
     abort: function () {
@@ -78,8 +80,11 @@ function retryRequest(requestOpts, opts, callback) {
       } else if (requestStream.end) {
         requestStream.end();
       }
-      
-      requestStream.removeAllListeners();
+
+      if (removeAllListeners) {
+        removeAllListeners();
+        removeAllListeners = null;
+      }
     }
   }
 
@@ -90,11 +95,24 @@ function retryRequest(requestOpts, opts, callback) {
       delayStream = through({ objectMode: opts.objectMode });
       requestStream = opts.request(requestOpts);
 
-      requestStream
-        .once('error', onResponse)
-        .once('response', onResponse.bind(null, null))
-        .once('complete', retryStream.emit.bind(retryStream, 'complete'))
-        .pipe(delayStream);
+      var events = {
+        error: onResponse,
+        response: onResponse.bind(null, null),
+        complete: retryStream.emit.bind(retryStream, 'complete')
+      };
+
+      for (var eventName in events) {
+        requestStream.once(eventName, events[eventName]);
+      }
+
+      removeAllListeners = function() {
+        for (var eventName in events) {
+          requestStream.on(eventName, function() {});
+          requestStream.removeListener(eventName, events[eventName]);
+        }
+      };
+
+      requestStream.pipe(delayStream);
     } else {
       activeRequest = opts.request(requestOpts, onResponse);
     }

--- a/index.js
+++ b/index.js
@@ -78,6 +78,8 @@ function retryRequest(requestOpts, opts, callback) {
       } else if (requestStream.end) {
         requestStream.end();
       }
+      
+      requestStream.removeAllListeners();
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -89,9 +89,9 @@ function retryRequest(requestOpts, opts, callback) {
       requestStream = opts.request(requestOpts);
 
       requestStream
-        .on('error', onResponse)
-        .on('response', onResponse.bind(null, null))
-        .on('complete', retryStream.emit.bind(retryStream, 'complete'))
+        .once('error', onResponse)
+        .once('response', onResponse.bind(null, null))
+        .once('complete', retryStream.emit.bind(retryStream, 'complete'))
         .pipe(delayStream);
     } else {
       activeRequest = opts.request(requestOpts, onResponse);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "node": ">=4"
   },
   "dependencies": {
+    "first-event": "^1.0.0",
     "request": "^2.81.0",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
this assigns once listeners instead of on, so that
response events are only handled once

investigative work behind this change: https://github.com/GoogleCloudPlatform/google-cloud-node/issues/2328#issuecomment-303821776