### PR TITLE
Add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,20 @@
+declare module 'retry-request' {
+  import * as request from 'request';
+
+  namespace retryRequest {
+    function getNextRetryDelay(retryNumber: number): void;
+    interface Options {
+      objectMode?: boolean,
+      request?: typeof request,
+      retries?: number,
+      shouldRetryFn?: (response: request.RequestResponse) => boolean
+    }
+  }
+
+  function retryRequest(requestOpts: request.Options, opts: retryRequest.Options, callback?: request.RequestCallback)
+    : { abort: () => void };
+  function retryRequest(requestOpts: request.Options, callback?: request.RequestCallback)
+    : { abort: () => void };
+
+  export = retryRequest;
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "index.d.ts",
     "license"
   ],
+  "types": "index.d.ts",
   "keywords": [
     "request",
     "retry",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "license"
   ],
   "keywords": [


### PR DESCRIPTION
It would be useful to have type definitions for this library as it's being used in `gcp-metadata`. This change adds it as `index.d.ts`.