### PR TITLE
Pass in currentRetryAttempt to override the numAttempts value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare module 'retry-request' {
       request?: typeof request,
       retries?: number,
       noResponseRetries?: number,
+      currentRetryAttempt?: number,
       shouldRetryFn?: (response: request.RequestResponse) => boolean
     }
   }

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var DEFAULTS = {
   request: request,
   retries: 2,
   noResponseRetries: 2,
+  currentRetryAttempt: 0,
   shouldRetryFn: function (response) {
     var retryRanges = [
       // https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
@@ -53,11 +54,13 @@ function retryRequest(requestOpts, opts, callback) {
     opts.retries = DEFAULTS.retries;
   }
   if (typeof opts.currentRetryAttempt !== 'number') {
-    opts.currentRetryAttempt = 0;
+    opts.currentRetryAttempt = DEFAULTS.currentRetryAttempt;
   }
   if (typeof opts.shouldRetryFn !== 'function') {
     opts.shouldRetryFn = DEFAULTS.shouldRetryFn;
   }
+
+  var currentRetryAttempt = opts.currentRetryAttempt;
 
   var numNoResponseAttempts = 0;
   var streamResponseHandled = false;
@@ -104,7 +107,7 @@ function retryRequest(requestOpts, opts, callback) {
   }
 
   function makeRequest() {
-    opts.currentRetryAttempt++;
+    currentRetryAttempt++;
 
     if (streamMode) {
       streamResponseHandled = false;
@@ -168,8 +171,8 @@ function retryRequest(requestOpts, opts, callback) {
     }
 
     // Send the response to see if we should try again.
-    if (opts.currentRetryAttempt <= opts.retries && opts.shouldRetryFn(response)) {
-      retryAfterDelay(opts.currentRetryAttempt);
+    if (currentRetryAttempt <= opts.retries && opts.shouldRetryFn(response)) {
+      retryAfterDelay(currentRetryAttempt);
       return;
     }
 

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,22 @@ request(urlThatReturns503, opts, function (err, resp, body) {
 });
 ```
 
+#### `opts.currentRetryAttempt`
+
+Type: `Number`
+
+Default: `0`
+
+```js
+var opts = {
+  currentRetryAttempt: 1
+};
+
+request(urlThatReturns503, opts, function (err, resp, body) {
+  // urlThatReturns503 was requested as if it already failed once.
+});
+```
+
 #### `opts.shouldRetryFn`
 
 Type: `Function`

--- a/test.js
+++ b/test.js
@@ -216,7 +216,7 @@ describe('retry-request', function () {
       };
 
       retryRequest(URI_404, opts, function (err) {
-        assert.deepEqual(numAttempts, 2);
+        assert.strictEqual(numAttempts, 2);
         done();
       });
     });

--- a/test.js
+++ b/test.js
@@ -120,7 +120,7 @@ describe('retry-request', function () {
         .on('error', done);
     });
 
-    it.only('forwards a request error', function (done) {
+    it('forwards a request error', function (done) {
       var error = new Error('Error.');
 
       var opts = {
@@ -192,7 +192,7 @@ describe('retry-request', function () {
 
       var opts = {
         noResponseRetries: 0,
-        request: function (opts, callback) {
+        request: function (_, callback) {
           numAttempts++;
           callback(error);
         }
@@ -201,6 +201,22 @@ describe('retry-request', function () {
       retryRequest(URI_NON_EXISTENT, opts, function (err) {
         assert.strictEqual(numAttempts, 1);
         assert.strictEqual(err, error);
+        done();
+      });
+    });
+
+    it('should allow overriding currentRetryAttempt', function (done) {
+      var numAttempts = 0;
+      var opts = {
+        currentRetryAttempt: 1,
+        request: function (_, responseHandler) {
+          numAttempts++;
+          responseHandler(null, { statusCode: 500 });
+        }
+      };
+
+      retryRequest(URI_404, opts, function (err) {
+        assert.deepEqual(numAttempts, 2);
         done();
       });
     });


### PR DESCRIPTION
Allow the user to pass in what attempt of the retry the request is at. This change allows having other APIs take over responsibilities without having to store all the request logic in one place.

For example see [this commit](https://github.com/kolodny/cloud-bigtable-examples/commit/1f0faafa075d48bb34e71c0386e44f0c0118336b) where a request is encapsulated by a library (service) to get a non error stream (`shouldRetryFn(response)` is false), yet the data for the service which uses the library (the consumer) is invalid and requires another request, if the request was to start again the retry attempt state would be reset on the service level. A similar problem would arise if the consumer errors and then the service also errors on the retry.
