### PR TITLE
Remove `request` as a dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var request = require('request');
 var through = require('through2');
 
 var DEFAULTS = {
   objectMode: false,
-  request: request,
   retries: 2,
   noResponseRetries: 2,
   currentRetryAttempt: 0,
@@ -48,7 +46,11 @@ function retryRequest(requestOpts, opts, callback) {
     opts.objectMode = DEFAULTS.objectMode;
   }
   if (typeof opts.request === 'undefined') {
-    opts.request = DEFAULTS.request;
+    try {
+      opts.request = require('request');
+    } catch (e) {
+      throw new Error('A request library must be provided to retry-request.');
+    }
   }
   if (typeof opts.retries !== 'number') {
     opts.retries = DEFAULTS.retries;

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "node": ">=4"
   },
   "dependencies": {
-    "request": "^2.81.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {
     "async": "^2.5.0",
     "lodash.range": "^3.2.0",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "request": "^2.87.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -3,15 +3,30 @@
 |Retry a [request][request] with built-in [exponential backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/coreErrors#backoff).
 
 ```sh
+$ npm install --save request
 $ npm install --save retry-request
 ```
 ```js
-var request = require('retry-request');
+var request = require('retry-request', {
+  request: require('request')
+});
 ```
 
 It should work the same as `request` in both callback mode and stream mode.
 
 Note: This module only works when used as a readable stream, i.e. POST requests aren't supported  ([#3](https://github.com/stephenplusplus/retry-request/issues/3)).
+
+## Do I need to install `request`?
+
+Yes! You must independently install `request` and provide it to this library:
+
+```js
+var request = require('retry-request', {
+  request: require('request')
+});
+```
+
+*The code will actually look for the `request` module automatically to save you this step. But, being explicit like in the example is also welcome.*
 
 #### Callback
 
@@ -125,7 +140,9 @@ request(urlThatReturnsNonOKStatusMessage, opts, function (err, resp, body) {
 
 Type: `Function`
 
-Default: [`request`][request]
+Default: `try { require('request') }`
+
+If we cannot locate `request`, we will throw an error advising you to provide it explicitly.
 
 *NOTE: If you override the request function, and it returns a stream in object mode, be sure to set `opts.objectMode` to `true`.*
 


### PR DESCRIPTION
# ⚠️ Major breakage!

This will remove `request` as a direct dependency. It will require a user to install `request` themselves,