### PR TITLE
fix: correctly calculate retry attempt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,23 +11,17 @@ install_and_test: &install_and_test
         command: npm test
 
 jobs:
-  test_node8:
-    docker:
-      - image: node:8
-    <<: *install_and_test
   test_node10:
     docker:
-      - image: node:10
+      - image: circleci/node:10
     <<: *install_and_test
-  test_node11:
+  test_node12:
     docker:
-      - image: node:11
+      - image: circleci/node:12
     <<: *install_and_test
 
 workflows:
-  version: 3
   test:
     jobs:
-      - test_node8
       - test_node10
-      - test_node11
+      - test_node12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 3
+version: 2.1
 
 install_and_test: &install_and_test
   steps:

--- a/test.js
+++ b/test.js
@@ -272,7 +272,7 @@ describe('retry-request', function () {
       };
 
       retryRequest(URI_404, opts, function (err) {
-        assert.strictEqual(numAttempts, 2);
+        assert.strictEqual(numAttempts, 1);
         done();
       });
     });


### PR DESCRIPTION
The code was confusing "retry attempts" with "request attempts". This sets the record straight.