### PR TITLE
Drop through2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var through = require('through2');
+var { Transform } = require('stream');
 var debug = require('debug')('retry-request');
 
 var DEFAULTS = {
@@ -89,7 +89,10 @@ function retryRequest(requestOpts, opts, callback) {
   };
 
   if (streamMode) {
-    retryStream = through({ objectMode: opts.objectMode });
+    retryStream = new Transform({
+      objectMode: opts.objectMode,
+      transform: (chunk, enc, cb) => cb(null, chunk)
+    });
     retryStream.abort = resetStreams;
   }
 
@@ -127,7 +130,10 @@ function retryRequest(requestOpts, opts, callback) {
     if (streamMode) {
       streamResponseHandled = false;
 
-      delayStream = through({ objectMode: opts.objectMode });
+      delayStream = new Transform({
+        objectMode: opts.objectMode,
+        transform: (chunk, enc, cb) => cb(null, chunk)
+      });
       requestStream = opts.request(requestOpts);
 
       setImmediate(function () {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var { Transform } = require('stream');
+var { PassThrough } = require('stream');
 var debug = require('debug')('retry-request');
 
 var DEFAULTS = {
@@ -89,10 +89,7 @@ function retryRequest(requestOpts, opts, callback) {
   };
 
   if (streamMode) {
-    retryStream = new Transform({
-      objectMode: opts.objectMode,
-      transform: (chunk, enc, cb) => cb(null, chunk)
-    });
+    retryStream = new PassThrough({ objectMode: opts.objectMode });
     retryStream.abort = resetStreams;
   }
 
@@ -130,10 +127,7 @@ function retryRequest(requestOpts, opts, callback) {
     if (streamMode) {
       streamResponseHandled = false;
 
-      delayStream = new Transform({
-        objectMode: opts.objectMode,
-        transform: (chunk, enc, cb) => cb(null, chunk)
-      });
+      delayStream = new PassThrough({ objectMode: opts.objectMode });
       requestStream = opts.request(requestOpts);
 
       setImmediate(function () {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "node": ">=8.10.0"
   },
   "dependencies": {
-    "debug": "^4.1.1",
-    "through2": "^3.0.1"
+    "debug": "^4.1.1"
   },
   "devDependencies": {
     "async": "^3.0.1",

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@
 var assert = require('assert');
 var async = require('async');
 var range = require('lodash.range');
-var { Transform } = require('stream');
+var { PassThrough } = require('stream');
 
 var retryRequest = require('./index.js');
 
@@ -48,7 +48,7 @@ describe('retry-request', function () {
           return requestsMade < 3;
         },
         request: function () {
-          var fakeRequestStream = new Transform();
+          var fakeRequestStream = new PassThrough();
 
           requestsMade++;
 
@@ -94,7 +94,7 @@ describe('retry-request', function () {
         request: function () {
           numAttempts++;
 
-          var fakeRequestStream = new Transform();
+          var fakeRequestStream = new PassThrough();
           fakeRequestStream.abort = function () {
             numAborts++;
           };
@@ -135,7 +135,7 @@ describe('retry-request', function () {
         request: function () {
           numAttempts++;
 
-          var fakeRequestStream = new Transform();
+          var fakeRequestStream = new PassThrough();
           fakeRequestStream.abort = function () {
             numAborts++;
           };
@@ -163,7 +163,7 @@ describe('retry-request', function () {
 
       var opts = {
         request: function () {
-          var fakeRequestStream = new Transform();
+          var fakeRequestStream = new PassThrough();
 
           setImmediate(function () {
             fakeRequestStream.emit('response', {

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@
 var assert = require('assert');
 var async = require('async');
 var range = require('lodash.range');
-var through = require('through2');
+var { Transform } = require('stream');
 
 var retryRequest = require('./index.js');
 
@@ -48,7 +48,7 @@ describe('retry-request', function () {
           return requestsMade < 3;
         },
         request: function () {
-          var fakeRequestStream = through();
+          var fakeRequestStream = new Transform();
 
           requestsMade++;
 
@@ -94,7 +94,7 @@ describe('retry-request', function () {
         request: function () {
           numAttempts++;
 
-          var fakeRequestStream = through();
+          var fakeRequestStream = new Transform();
           fakeRequestStream.abort = function () {
             numAborts++;
           };
@@ -135,7 +135,7 @@ describe('retry-request', function () {
         request: function () {
           numAttempts++;
 
-          var fakeRequestStream = through();
+          var fakeRequestStream = new Transform();
           fakeRequestStream.abort = function () {
             numAborts++;
           };
@@ -163,7 +163,7 @@ describe('retry-request', function () {
 
       var opts = {
         request: function () {
-          var fakeRequestStream = through();
+          var fakeRequestStream = new Transform();
 
           setImmediate(function () {
             fakeRequestStream.emit('response', {


### PR DESCRIPTION
Ref https://github.com/rvagg/through2#do-you-need-this

Node builtin stream.PassThrough handles same functionality just fine on
node 8+. Two dependencies (also readable-stream) can be dropped.