### PR TITLE
fix: use extend instead of object.assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var { PassThrough } = require('stream');
 var debug = require('debug')('retry-request');
+var extend = require('extend');
 
 var DEFAULTS = {
   objectMode: false,
@@ -66,7 +67,7 @@ function retryRequest(requestOpts, opts, callback) {
   }
 
   var manualCurrentRetryAttemptWasSet = opts && typeof opts.currentRetryAttempt === 'number';
-  opts = Object.assign({}, DEFAULTS, opts);
+  opts = extend({}, DEFAULTS, opts);
 
   if (typeof opts.request === 'undefined') {
     try {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "node": ">=8.10.0"
   },
   "dependencies": {
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "extend": "^3.0.2"
   },
   "devDependencies": {
     "async": "^3.0.1",

--- a/test.js
+++ b/test.js
@@ -216,6 +216,25 @@ describe('retry-request', function () {
   });
 
   describe('overriding', function () {
+    it('should ignore undefined options', function (done) {
+      var numAttempts = 0;
+      var error = new Error('ENOTFOUND');
+
+      var opts = {
+        noResponseRetries: undefined,
+        request: function (_, callback) {
+          numAttempts++;
+          callback(error);
+        }
+      };
+
+      retryRequest(URI_NON_EXISTENT, opts, function (err) {
+        assert.strictEqual(numAttempts, 3);
+        assert.strictEqual(err, error);
+        done();
+      });
+    });
+
     it('should allow overriding retries', function (done) {
       var opts = { retries: 0 };
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-common/pull/680#discussion_r667151112

Object.assign favors undefined options.